### PR TITLE
Update .spi.yml for autogenerating documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [Glider,GliderSwiftLog,GliderELK,GliderNetWatcher,GliderSentry]
+    - documentation_targets: [Glider]


### PR DESCRIPTION
Doc generation in SPI fails, because it's referencing non-existing targets!